### PR TITLE
Solve Python deadlocks by only executing code on global interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,9 +437,7 @@ output:
 > Note the use of `mode: global`!
 
 ### `pyarrow`
-Works fine in `global` mode, but you need to prime the `input` by explicitly
-setting a `modules` config to load `pyarrow` prior to your script
-execution.
+Works fine in `global` mode.
 
 An example follows using the `pyarrow.dataset` capabilities to read from GCS.
 
@@ -450,8 +448,6 @@ input:
   python:
     name: batches
     serializer: none
-    modules:
-      - pyarrow
     script: |
       import pyarrow as pa
       from pyarrow import fs

--- a/examples/pyarrow.yaml
+++ b/examples/pyarrow.yaml
@@ -2,8 +2,6 @@ input:
   python:
     name: batches
     serializer: none
-    modules:
-      - pyarrow
     script: |
       import pyarrow as pa
       from pyarrow import fs

--- a/input/python.go
+++ b/input/python.go
@@ -34,7 +34,6 @@ type pythonInput struct {
 
 	args          py.PyObjectPtr
 	kwargs        py.PyObjectPtr
-	modules       []string
 	script        string
 	generatorName string
 	idx           int64
@@ -55,8 +54,6 @@ var configSpec = service.NewConfigSpec().
 	Field(service.NewIntField("batch_size").
 		Description("Size of batches to generate.").
 		Default(1)).
-	Field(service.NewStringListField("modules").
-		Description("A list of Python function modules to pre-import.")).
 	Field(service.NewStringField("mode").
 		Description("Toggle different Python runtime modes.").
 		Examples(string(python.Global), string(python.Isolated), string(python.IsolatedLegacy)).
@@ -96,11 +93,8 @@ func init() {
 			if err != nil {
 				return nil, err
 			}
-			modules, err := conf.FieldStringList("modules")
-			if err != nil {
-				modules = []string{}
-			}
-			return newPythonInput(exe, script, name, modules, batchSize, python.StringAsMode(mode), python.StringAsSerializerMode(serializerMode), mgr.Logger())
+
+			return newPythonInput(exe, script, name, batchSize, python.StringAsMode(mode), python.StringAsSerializerMode(serializerMode), mgr.Logger())
 		})
 
 	if err != nil {
@@ -108,7 +102,7 @@ func init() {
 	}
 }
 
-func newPythonInput(exe, script, name string, modules []string, batchSize int, mode python.Mode, serializer python.SerializerMode, logger *service.Logger) (service.BatchInput, error) {
+func newPythonInput(exe, script, name string, batchSize int, mode python.Mode, serializer python.SerializerMode, logger *service.Logger) (service.BatchInput, error) {
 	var err error
 	var r python.Runtime
 
@@ -142,7 +136,6 @@ func newPythonInput(exe, script, name string, modules []string, batchSize int, m
 		batchSize:      batchSize,
 		boundsHint:     -1,
 		serializerMode: serializer,
-		modules:        modules,
 	}, nil
 }
 
@@ -150,13 +143,6 @@ func (p *pythonInput) Connect(ctx context.Context) error {
 	err := p.runtime.Start(ctx)
 	if err != nil {
 		return err
-	}
-
-	if len(p.modules) > 0 {
-		err = python.LoadModules(p.modules, ctx)
-		if err != nil {
-			return err
-		}
 	}
 
 	err = p.runtime.Map(ctx, func(_ *python.InterpreterTicket) error {

--- a/input/python.go
+++ b/input/python.go
@@ -117,7 +117,7 @@ func newPythonInput(exe, script, name string, batchSize int, mode python.Mode, s
 	case python.IsolatedLegacy:
 		r, err = python.NewMultiInterpreterRuntime(exe, 1, true, logger)
 	case python.Global:
-		r, err = python.NewSingleInterpreterRuntime(exe, logger)
+		r, err = python.NewSingleInterpreterRuntime(exe, 1, logger)
 	case python.Isolated:
 		r, err = python.NewMultiInterpreterRuntime(exe, 1, false, logger)
 	default:

--- a/internal/impl/python/common.go
+++ b/internal/impl/python/common.go
@@ -1,6 +1,9 @@
 package python
 
-import "strings"
+import (
+	py "github.com/voutilad/gogopython"
+	"strings"
+)
 
 type Mode string
 
@@ -53,3 +56,10 @@ func StringAsSerializerMode(s string) SerializerMode {
 }
 
 const SerializerMetaKey = "_python_serializer"
+
+// SubInterpreter state to allow multi-interpreter runtimes.
+type SubInterpreter struct {
+	State  py.PyInterpreterStatePtr // Interpreter State.
+	Thread py.PyThreadStatePtr      // Original Python ThreadState.
+	Id     int64                    // Unique identifier.
+}

--- a/internal/impl/python/common.go
+++ b/internal/impl/python/common.go
@@ -1,7 +1,6 @@
 package python
 
 import (
-	py "github.com/voutilad/gogopython"
 	"strings"
 )
 
@@ -56,10 +55,3 @@ func StringAsSerializerMode(s string) SerializerMode {
 }
 
 const SerializerMetaKey = "_python_serializer"
-
-// SubInterpreter state to allow multi-interpreter runtimes.
-type SubInterpreter struct {
-	State  py.PyInterpreterStatePtr // Interpreter State.
-	Thread py.PyThreadStatePtr      // Original Python ThreadState.
-	Id     int64                    // Unique identifier.
-}

--- a/internal/impl/python/multi.go
+++ b/internal/impl/python/multi.go
@@ -53,11 +53,7 @@ func (r *MultiInterpreterRuntime) Start(ctx context.Context) error {
 	defer globalMtx.Unlock()
 
 	if !r.started {
-		ts, err := loadPython(r.exe, r.home, r.paths, ctx)
-		if err != nil || ts == py.NullThreadState {
-			r.logger.Errorf("Failed to start Python interpreter.")
-			return err
-		}
+		loadPython(r.exe, r.home, r.paths, ctx)
 		r.logger.Debug("Python interpreter started.")
 
 		// Start up sub-interpreters.

--- a/internal/impl/python/runtime.go
+++ b/internal/impl/python/runtime.go
@@ -132,15 +132,13 @@ type Runtime interface {
 // On failure, returns a null PyThreadStatePtr and an error.
 //
 // Must be called globalMtx and the OS thread locked.
-func loadPython(exe, home string, paths []string, ctx context.Context) (py.PyThreadStatePtr, error) {
+func loadPython(exe, home string, paths []string, ctx context.Context) {
 	globalMtx.AssertLocked()
 
 	// It's ok if we're starting another instance of the same executable, but
 	// we don't want to re-load the libraries as we'll crash.
 	if exe != pythonExe && pythonLoaded {
 		panic("python was already initialized with a different implementation")
-		//return py.NullThreadState,
-		//	errors.New("python was already initialized with a different implementation")
 	}
 
 	// Load our dynamic libraries. This should happen only once per process
@@ -149,7 +147,6 @@ func loadPython(exe, home string, paths []string, ctx context.Context) (py.PyThr
 		err := py.LoadLibrary(exe)
 		if err != nil {
 			panic(err)
-			// return py.NullThreadState, err
 		}
 
 		// From now on, we're considered "loaded."
@@ -185,8 +182,6 @@ func loadPython(exe, home string, paths []string, ctx context.Context) (py.PyThr
 			panic(ctx.Err())
 		}
 	}
-
-	return pythonMain, nil
 }
 
 // unloadPython tears down the global interpreter state.

--- a/internal/impl/python/single.go
+++ b/internal/impl/python/single.go
@@ -49,11 +49,7 @@ func (r *SingleInterpreterRuntime) Start(ctx context.Context) error {
 		return nil
 	}
 
-	_, err = loadPython(r.exe, r.home, r.paths, ctx)
-	if err != nil {
-		return err
-	}
-
+	loadPython(r.exe, r.home, r.paths, ctx)
 	r.ticket.cookie = uintptr(unsafe.Pointer(r))
 	r.started = true
 	r.logger.Debug("Python single runtime interpreter started.")

--- a/output/python.go
+++ b/output/python.go
@@ -18,8 +18,6 @@ var configSpec = service.NewConfigSpec().
 		Description("Toggle different Python runtime modes.").
 		Examples(string(python.Global), string(python.Isolated), string(python.IsolatedLegacy)).
 		Default(string(python.Global))).
-	Field(service.NewStringListField("modules").
-		Description("A list of Python function modules to pre-import.")).
 	Field(service.NewStringField("serializer").
 		Description("Serialization mode to use on results.").
 		Examples(string(python.None), string(python.Pickle), string(python.Bloblang)).
@@ -48,11 +46,8 @@ func init() {
 			if err != nil {
 				return nil, policy, 0, err
 			}
-			modules, err := conf.FieldStringList("modules")
-			if err != nil {
-				return nil, policy, 0, err
-			}
-			p, err := processor.NewPythonProcessor(exe, script, modules, 1, python.StringAsMode(modeString), python.Bloblang, mgr.Logger())
+
+			p, err := processor.NewPythonProcessor(exe, script, 1, python.StringAsMode(modeString), python.Bloblang, mgr.Logger())
 			if err != nil {
 				return nil, policy, 0, err
 			}

--- a/processor/python.go
+++ b/processor/python.go
@@ -88,8 +88,6 @@ func init() {
 			Description("Toggle different Python runtime modes.").
 			Examples(string(python.Global), string(python.Isolated), string(python.IsolatedLegacy)).
 			Default(string(python.Global))).
-		Field(service.NewStringListField("modules").
-			Description("A list of Python function modules to pre-import.")).
 		Field(service.NewStringField("serializer").
 			Description("Serialization mode to use on results.").
 			Examples(string(python.None), string(python.Pickle), string(python.Bloblang)).
@@ -115,13 +113,8 @@ func init() {
 			if err != nil {
 				return nil, err
 			}
-			modules, err := conf.FieldStringList("modules")
-			if err != nil {
-				return nil, err
-			}
 
-			return NewPythonProcessor(exe, script, modules,
-				runtime.NumCPU(),
+			return NewPythonProcessor(exe, script, runtime.NumCPU(),
 				python.StringAsMode(modeString),
 				python.StringAsSerializerMode(serializer),
 				mgr.Logger())
@@ -137,7 +130,7 @@ func init() {
 //
 // This will create and initialize a new sub-interpreter from the main Python
 // Go routine and precompile some Python code objects.
-func NewPythonProcessor(exe, script string, modules []string, cnt int, mode python.Mode, serializer python.SerializerMode,
+func NewPythonProcessor(exe, script string, cnt int, mode python.Mode, serializer python.SerializerMode,
 	logger *service.Logger) (service.BatchProcessor, error) {
 
 	var err error
@@ -173,13 +166,6 @@ func NewPythonProcessor(exe, script string, modules []string, cnt int, mode pyth
 	err = processor.runtime.Start(ctx)
 	if err != nil {
 		return nil, err
-	}
-
-	if len(modules) > 0 {
-		err = python.LoadModules(modules, ctx)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	// Initialize our sub-interpreter state.

--- a/processor/python.go
+++ b/processor/python.go
@@ -151,7 +151,7 @@ func NewPythonProcessor(exe, script string, cnt int, mode python.Mode, serialize
 	case python.IsolatedLegacy:
 		processor, err = newLegacyRuntimeProcessor(exe, cnt, logger)
 	case python.Global:
-		processor, err = newSingleRuntimeProcessor(exe, logger)
+		processor, err = newSingleRuntimeProcessor(exe, cnt, logger)
 	default:
 		return nil, errors.New("invalid mode")
 	}
@@ -319,8 +319,8 @@ func newLegacyRuntimeProcessor(exe string, cnt int, logger *service.Logger) (*Py
 	return &p, nil
 }
 
-func newSingleRuntimeProcessor(exe string, logger *service.Logger) (*PythonProcessor, error) {
-	r, err := python.NewSingleInterpreterRuntime(exe, logger)
+func newSingleRuntimeProcessor(exe string, cnt int, logger *service.Logger) (*PythonProcessor, error) {
+	r, err := python.NewSingleInterpreterRuntime(exe, cnt, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/processor/python_test.go
+++ b/processor/python_test.go
@@ -25,7 +25,7 @@ func TestDifferentInterpreterModes(t *testing.T) {
 
 	for _, m := range []python.Mode{python.Isolated, python.IsolatedLegacy, python.Global} {
 		t.Run(string(m), func(t *testing.T) {
-			proc, err := NewPythonProcessor("python3", script, nil, runtime.NumCPU(), m, python.Bloblang, nil)
+			proc, err := NewPythonProcessor("python3", script, runtime.NumCPU(), m, python.Bloblang, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/test.yaml
+++ b/test.yaml
@@ -16,6 +16,7 @@ pipeline:
     - python:
         mode: isolated
         script: |
+          print("HERE")
           # Return a lowercase version.
           msg = content().decode()
           root = msg.lower()

--- a/test.yaml
+++ b/test.yaml
@@ -16,7 +16,6 @@ pipeline:
     - python:
         mode: isolated
         script: |
-          print("HERE")
           # Return a lowercase version.
           msg = content().decode()
           root = msg.lower()


### PR DESCRIPTION
When _not_ using sub-interpreters (e.g. mode `isolated` or `isolated_legacy`), certain Python modules that do lots of funky stuff behind the scenes using native libraries can cause frustrating-to-debug deadlocks in the Python interpreter integration.

This redesign moves all execution of `global` interpreter Python code to the "main" Go routine that manages the interpreter. This seems to fix the deadlocks and allows for dropping the `modules: []` config property, too.

This does make it look like we need a future rewrite to clean up and merge more of the overlap between the single and multi-interpreter code.